### PR TITLE
ios9 fix

### DIFF
--- a/Pod/Classes/Objective-C/UIAppearance+Swift.m
+++ b/Pod/Classes/Objective-C/UIAppearance+Swift.m
@@ -15,7 +15,7 @@
     NSUInteger count = containers.count;
     NSAssert(count <= 10, @"The count of containers greater than 10 is not supported.");
     
-    return [self appearanceWhenContainedIn:
+    return [self appearanceWhenContainedInInstancesOfClasses:@[
             count > 0 ? containers[0] : nil,
             count > 1 ? containers[1] : nil,
             count > 2 ? containers[2] : nil,
@@ -25,8 +25,6 @@
             count > 6 ? containers[6] : nil,
             count > 7 ? containers[7] : nil,
             count > 8 ? containers[8] : nil,
-            count > 9 ? containers[9] : nil,
-            nil];
+            count > 9 ? containers[9] : nil]];
 }
-
 @end


### PR DESCRIPTION
" 'appearanceWhenContainedIn:' is deprecated: first deprecated in iOS 9.0 " warning fixed.